### PR TITLE
ファイルオープンダイアログにおける拡張子の修正

### DIFF
--- a/Assets/Scripts/QuiltFileLoader.cs
+++ b/Assets/Scripts/QuiltFileLoader.cs
@@ -324,7 +324,8 @@ public class QuiltFileLoader : MonoBehaviour
     {
         // Standalone File Browserを利用
         var extensions = new[] {
-                new ExtensionFilter("Image Files", "png", "jpg", "jpeg" ),
+//                new ExtensionFilter("Image Files", "png", "jpg", "jpeg" ),
+                new ExtensionFilter("Movie Files", "mp4" ),
                 new ExtensionFilter("All Files", "*" ),
             };
         string[] files = StandaloneFileBrowser.OpenFilePanel("Open File", "", extensions, false);


### PR DESCRIPTION
マウスの右ボタンクリックまたは「O」ボタンを押したときにファイルの選択ダイアログが出いますが、画像ファイル(jpg, pngなど)が設定されています。しかし、このプロジェクトは動画(mp4)のみにしか対応できていないようなのでコードを変えて動画のみにしました。